### PR TITLE
Setup video conference integration work

### DIFF
--- a/app/firebase/firebase.py
+++ b/app/firebase/firebase.py
@@ -86,6 +86,15 @@ def saveWorkshopState(data):
 	companies.updateCompanyData(db, updatedCompany)
 	return updatedCompany
 
+# Work on this function
+# def scheduleVideoConference(data):
+# 	# get company byId
+# 	updatedCompany = companies.getCompanyById(db, data["companyId"])
+# 	# Add zoom details from api here:
+# 	updatedCompany = inPersonWorkshopManager.scheduleVideoConferenceDate(updatedCompany, data["moduleId"], data["datetime"])
+# 	companies.updateCompanyData(db, updatedCompany)
+# 	return updatedCompany
+
 # For random tests on startup
 # modules2 = db.collection(u'companies').where("participants", "array_contains", "vYXqTtUPwIfYtQnMu1JazQLtxxK2").get()
 # finalModules = []

--- a/app/firebase/inPersonWorkshopManager.py
+++ b/app/firebase/inPersonWorkshopManager.py
@@ -205,3 +205,17 @@ def saveWorkshopState(companyToUpdate, moduleId, workshops):
 		if moduleId in companyToUpdate["inPersonWorkshops"]:
 			companyToUpdate["inPersonWorkshops"][moduleId] = workshops
 	return companyToUpdate
+
+
+# def scheduleVideoConferenceDate(companyToUpdate, moduleId, date):
+	# TODO:
+	# 1. Call zoom api to create a new zoom meeting
+	# Final object should look like:
+	# zoomlinkObj = {
+	# 	"zoomUrl": "zoom.com/adqo9jqwodqo",
+	# 	"workshopDate": date
+	# }
+	# 2. Add this object to the companyToUpdate
+	# companyToUpdate["inPersonWorkshops"][moduleId][videoConferenceDate] = zoomlinkObj
+	# 3. Return company to update
+	# return companyToUpdate

--- a/app/routes.py
+++ b/app/routes.py
@@ -71,3 +71,8 @@ def createInPersonWorkshops():
 @app.route('/saveWorkshopState', methods=['POST'])
 def saveWorkshopState():
 	return firebase.saveWorkshopState(request.get_json())
+
+# Add new route here
+# @app.route('/scheduleVideoConference', methods=['POST'])
+# def scheduleVideoConference():
+# 	return firebase.scheduleVideoConference(request.get_json())


### PR DESCRIPTION
The user must be able to schedule a new zoom meeting at the end of the in-person workshops. Once the event is scheduled, the date / time and event name is saved.

**Starting instructions are included in the initial commit of this branch.**

### Acceptance Criteria:
- User can schedule a new in-person workshop video conference for a specified date and time, including a name for the conference event and zoom link to join it.
- Once it is scheduled, all users will be able to get access the zoom link in their home page
- The admin can schedule an unlimited number of video conferences, and delete / edit any of them as they please

**The desired order of milestones are:**
- User can create as many video conference events as desired
- User can delete each video conference event
- User can edit each video conference event